### PR TITLE
Fix unnecessary line breaks in default config file.

### DIFF
--- a/src/package.py
+++ b/src/package.py
@@ -89,7 +89,7 @@ def main():
     source_name = "backup-docker-compose.py"
     dest_name = "backup-docker-compose-withoutTypes.py"
     with open(source_name, "r") as sourceFile:
-        source = "\n".join(sourceFile.readlines())
+        source = "".join(sourceFile.readlines())
         dest = remove_type_hints(source)
         with open(dest_name, "w") as destFile:
             destFile.write(dest)


### PR DESCRIPTION
The default config file that was auto-generated at first startup of the program contained too many line breaks and therefore became confusing. These line breaks were "injected" automatically.
<details>
<summary>Default configuration file backup.ini without this fix.</summary>

```

#This is the default config of the rsnapshot-docker-compose-backup program.



#This section can contain rsnapshot commands that are executed in the different steps of the container backup

[default_config]

#Example:

#run_backup=backup_script   echo "Hello" > helloWorld   test/



[default_config.vars]

#This setting corresponds to the var with the same name and can be used as a prefix in the folder path

backupprefixfolder = .



#This Section controls which actions should be enabled

[default_config.actions]

#This action stops the container before copying the volumes and starts it after it finished.

stopcontainer = true



#This action backups all volumes of the container

volumebackup = true



#This action saves the docker-compose.yml

yamlbackup = true

imagebackup = true



#The following actions are disabled by default

logbackup = false

projectDirBackup = false



#The following is the definition of actions that can be used in the backup



[actions.volumeBackup]

backup = backup $volumes.path   $backupPrefixFolder/$serviceName/$volumes.name



[actions.yamlBackup]

runtime_backup = backup $projectFolder  $backupPrefixFolder/$serviceName/yaml   +rsync_long_args=--include=*.yml,+rsync_long_args=--include=*.yaml



[actions.projectDirBackup]

backup = backup $projectFolder  $backupPrefixFolder/$serviceName/projectDir



[actions.imageBackup]

runtime_backup = backup_script  /usr/bin/docker image save $image -o $serviceName_image.tar     $backupPrefixFolder/$serviceName/image



[actions.logBackup]

backup = backup_script  /usr/bin/docker logs $containerID > $serviceName_logs.log       $backupPrefixFolder/$serviceName/log



[actions.stopContainer]

stop = backup_exec      cd $projectFolder; /usr/bin/docker-compose stop

restart = backup_exec   cd $projectFolder; /usr/bin/docker-compose start


```
</details>

<details>
<summary>Default configuration file backup.ini after this fix.</summary>

```

#This is the default config of the rsnapshot-docker-compose-backup program.

#This section can contain rsnapshot commands that are executed in the different steps of the container backup
[default_config]
#Example:
#run_backup=backup_script   echo "Hello" > helloWorld   test/

[default_config.vars]
#This setting corresponds to the var with the same name and can be used as a prefix in the folder path
backupprefixfolder = .

#This Section controls which actions should be enabled
[default_config.actions]
#This action stops the container before copying the volumes and starts it after it finished.
stopcontainer = true

#This action backups all volumes of the container
volumebackup = true

#This action saves the docker-compose.yml
yamlbackup = true
imagebackup = true

#The following actions are disabled by default
logbackup = false
projectDirBackup = false

#The following is the definition of actions that can be used in the backup

[actions.volumeBackup]
backup = backup $volumes.path   $backupPrefixFolder/$serviceName/$volumes.name

[actions.yamlBackup]
runtime_backup = backup $projectFolder  $backupPrefixFolder/$serviceName/yaml   +rsync_long_args=--include=*.yml,+rsync_long_args=--include=*.yaml

[actions.projectDirBackup]
backup = backup $projectFolder  $backupPrefixFolder/$serviceName/projectDir

[actions.imageBackup]
runtime_backup = backup_script  /usr/bin/docker image save $image -o $serviceName_image.tar     $backupPrefixFolder/$serviceName/image

[actions.logBackup]
backup = backup_script  /usr/bin/docker logs $containerID > $serviceName_logs.log       $backupPrefixFolder/$serviceName/log

[actions.stopContainer]
stop = backup_exec      cd $projectFolder; /usr/bin/docker-compose stop
restart = backup_exec   cd $projectFolder; /usr/bin/docker-compose start


```
</details>

 