### PR TITLE
Support all (four) valid names for compose files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 [project]
 name = "rsnapshot-docker-compose-backup"
-version = "0.9.5"
+version = "0.9.6"
 authors = [
   { name="Christpoph Wildhagen", email="git@christoph-wildhagen.de" },
 ]

--- a/src/rsnapshot_docker_compose_backup/docker_compose.py
+++ b/src/rsnapshot_docker_compose_backup/docker_compose.py
@@ -60,9 +60,17 @@ def find_docker_dirs(root_folder: str = os.getcwd()) -> List[str]:
     """Finds all docker-compose dirs in current sub folder
     :returns: a list of all folders"""
     dirs: List[str] = []
+    docker_compose_files = [
+        "compose.yaml",
+        "compose.yml",
+        "docker-compose.yaml",
+        "docker-compose.yml",
+    ]
     for tree_element in os.walk(root_folder):
-        if "docker-compose.yml" in tree_element[2]:
-            dirs.append(tree_element[0])
+        for docker_compose_file in docker_compose_files:
+            if docker_compose_file in tree_element[2]:
+                dirs.append(tree_element[0])
+                break
     return dirs
 
 


### PR DESCRIPTION
This uses a list of the valid names instead of the regex, because
I find it easier to read
Fixes #7