### PR TITLE
Add compose project name to generated rsnapshot configuration

### DIFF
--- a/src/rsnapshot_docker_compose_backup/container.py
+++ b/src/rsnapshot_docker_compose_backup/container.py
@@ -40,9 +40,17 @@ class Container:
         if output is None:
             # print("output is none")
             return ""
-        result.append("##Start backup for compose project {} - service {}".format(self.project_name, self.service_name))
+        result.append(
+            "##Start backup for compose project {} - service {}".format(
+                self.project_name, self.service_name
+            )
+        )
         result.append(output)
-        result.append("##End backup for compose project {} - service {}".format(self.project_name, self.service_name))
+        result.append(
+            "##End backup for compose project {} - service {}".format(
+                self.project_name, self.service_name
+            )
+        )
         result.append("")
         return "\n".join(result)
 

--- a/src/rsnapshot_docker_compose_backup/container.py
+++ b/src/rsnapshot_docker_compose_backup/container.py
@@ -40,8 +40,9 @@ class Container:
         if output is None:
             # print("output is none")
             return ""
-        result.append("#Start {}".format(self.service_name))
+        result.append("##Start backup for compose project {} - service {}".format(self.project_name, self.service_name))
         result.append(output)
+        result.append("##End backup for compose project {} - service {}".format(self.project_name, self.service_name))
         result.append("")
         return "\n".join(result)
 


### PR DESCRIPTION
Alter generated rsnapshot configuration. As service names are not unique, this change helps identifying the container and compose project for which the rsnapshot configuration is generated.

Before:
```
#Start app-1
#runtime_backup
[...]

#Start app-1
#runtime_backup
[...]
```
After:
```
##Start backup for compose project wikicomposeProj1 - service app-1
#runtime_backup
[...]

##Start backup for compose project wikicomposeProj2 - service app-1
#runtime_backup
[...]
```