### PR TITLE
Improve CI Scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   multiversion:
+    name: flake8 checks
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,6 +35,7 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
   singleversion:
+    name: MyPy and Black checks
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,6 @@ jobs:
   singleversion:
     name: MyPy and Black checks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install mypy black pytest
       - name: Validate types with mypy
-        run: |
-          mypy .
-          black --check .
+        run: mypy .
+      - name: Check formatting with black
+        # Run Job even if mypy fails. This would also run if a previous step failed, but that shouldn't happen
+        if: always()
+        run: black --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Install pypa/build
@@ -22,7 +22,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
This fixes various smaller issues with the current CI Scrips:
- Better Naming of lint jobs
- Split mypy and black to different steps for better errors
- Run black if mypy fails
- Run flake on Python 3.12
- Update versions of actions in relase script 